### PR TITLE
remove /sys/fs/cgroup mount inside container

### DIFF
--- a/src/bpm/runc/adapter/adapter.go
+++ b/src/bpm/runc/adapter/adapter.go
@@ -268,12 +268,6 @@ func defaultMounts() []specs.Mount {
 			Source:      "sysfs",
 			Options:     []string{"nosuid", "noexec", "nodev", "ro"},
 		},
-		{
-			Destination: "/sys/fs/cgroup",
-			Type:        "cgroup",
-			Source:      "cgroup",
-			Options:     []string{"nosuid", "noexec", "nodev", "relatime", "ro"},
-		},
 	}
 }
 

--- a/src/bpm/runc/adapter/adapter_test.go
+++ b/src/bpm/runc/adapter/adapter_test.go
@@ -191,12 +191,6 @@ var _ = Describe("RuncAdapter", func() {
 					Options:     []string{"nosuid", "noexec", "nodev", "ro"},
 				},
 				{
-					Destination: "/sys/fs/cgroup",
-					Type:        "cgroup",
-					Source:      "cgroup",
-					Options:     []string{"nosuid", "noexec", "nodev", "relatime", "ro"},
-				},
-				{
 					Destination: "/bin",
 					Type:        "bind",
 					Source:      "/bin",


### PR DESCRIPTION
* unnecessarily exposes information about cgroups